### PR TITLE
Fix consumer group requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **[FEATURE] Add support for Okta as an identity provider**
 - [FEATURE] Support for hosting under a sub-path ([#107](https://github.com/cloudhut/kowl/issues/107) and [#117](https://github.com/cloudhut/kowl/issues/117))
 - [BUGFIX] Kowl now shows the error reported by a login provider (should the login fail)
+- [BUGFIX] Better handling for broker restarts on consumer groups and topics page
 
 ## 1.1.0 / 2020-08-06
 

--- a/backend/pkg/api/handle_consumer_group.go
+++ b/backend/pkg/api/handle_consumer_group.go
@@ -19,7 +19,7 @@ func (api *API) handleGetConsumerGroups() http.HandlerFunc {
 			restErr := &rest.Error{
 				Err:      err,
 				Status:   http.StatusInternalServerError,
-				Message:  "Could not describe consumer groups in the Kafka cluster",
+				Message:  "Could not get consumer groups overview",
 				IsSilent: false,
 			}
 			rest.SendRESTError(w, r, api.Logger, restErr)

--- a/backend/pkg/kafka/connection_helper.go
+++ b/backend/pkg/kafka/connection_helper.go
@@ -23,8 +23,8 @@ func NewSaramaConfig(cfg *Config) (*sarama.Config, error) {
 	}
 	sConfig.ClientID = cfg.ClientID
 	sConfig.Version = version
-	sConfig.Net.KeepAlive = 30 * time.Second
-	sConfig.Net.DialTimeout = 10 * time.Second
+	sConfig.Net.KeepAlive = 15 * time.Second
+	sConfig.Net.DialTimeout = 15 * time.Second
 	sConfig.Net.ReadTimeout = 15 * time.Second
 	sConfig.Net.WriteTimeout = 15 * time.Second
 

--- a/backend/pkg/kafka/service.go
+++ b/backend/pkg/kafka/service.go
@@ -117,6 +117,14 @@ func (s *Service) keepAlive() {
 				log.Warn("heartbeat: lost connection to broker", zap.Error(err), zap.String("broker", broker.Addr()), zap.Int32("id", broker.ID()))
 				_ = broker.Close()
 				_ = broker.Open(s.Client.Config())
+
+				log.Info("trying to refresh cluster metadata after we've lost connection to at least one broker")
+				metadataErr := s.Client.RefreshMetadata()
+				if metadataErr == nil {
+					log.Info("refreshed cluster metadata successfully")
+				} else {
+					log.Warn("failed to refresh cluster metadata after we've lost connection to at least one broker")
+				}
 				continue
 			}
 

--- a/backend/pkg/owl/topic_consumers.go
+++ b/backend/pkg/owl/topic_consumers.go
@@ -19,7 +19,7 @@ func (s *Service) ListTopicConsumers(ctx context.Context, topicName string) ([]*
 		return nil, fmt.Errorf("failed to list consumer groups: %w", err)
 	}
 
-	lags, err := s.getConsumerGroupLags(ctx, groups)
+	lags, err := s.getConsumerGroupLags(ctx, groups.GroupIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get consumer group lags: %w", err)
 	}

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -13,7 +13,7 @@ import { appGlobal } from "./appGlobal";
 import { uiState } from "./uiState";
 import { notification } from "antd";
 
-const REST_TIMEOUT_SEC = IsDev ? 5 : 25;
+const REST_TIMEOUT_SEC = 25;
 export const REST_CACHE_DURATION_SEC = 20;
 const REST_DEBUG_BASE_URL = null// || "http://localhost:9090"; // only uncommented using "npm run build && serve -s build"
 


### PR DESCRIPTION
This PR addresses issue #132 and #102 

Especially #102 is resolved on a best effort here as some requests may need to be triggered a second time. Reason for this is that Sarama utilizes several caches which we purge after a request has failed. If this is the case we do not retry the whole request chain as it would likely timeout anyways.

I intend to address this by potentially migrating to a library that exposes more core level functionality. https://github.com/twmb/kafka-go seems to be a good condidate to evaluate for this.