### PR TITLE
Fix render error when displaying json types (fixes issue #143)

### DIFF
--- a/frontend/src/components/misc/Card.tsx
+++ b/frontend/src/components/misc/Card.tsx
@@ -4,7 +4,7 @@ import React, { ReactNode, Component, CSSProperties } from "react";
 class Card extends Component<{ style?: CSSProperties, className?: string }> {
 
     render() {
-        return <div className={'kowlCard ' + this.props.className} style={this.props.style}>
+        return <div className={'kowlCard ' + (this.props.className ?? '')} style={this.props.style}>
             {this.props.children}
         </div>
     }

--- a/frontend/src/components/misc/ErrorBoundary.tsx
+++ b/frontend/src/components/misc/ErrorBoundary.tsx
@@ -7,6 +7,7 @@ import { CopyOutlined, CloseOutlined } from "@ant-design/icons";
 import { envVarDebugAr } from "../../utils/env";
 import { NoClipboardPopover } from "./NoClipboardPopover";
 import { isClipboardAvailable } from "../../utils/featureDetection";
+import { ObjToKv } from "../../utils/tsxUtils";
 
 const { Content, Footer, Sider, Header } = Layout;
 
@@ -91,6 +92,23 @@ export class ErrorBoundary extends React.Component {
             })
         } catch (ex) {
             this.infoItems.push({ name: "Environment", value: "(error retreiving env list)" });
+        }
+
+        // Location
+        try {
+            const loc = ObjToKv({
+                "Protocol": window?.location?.protocol ?? '<null>',
+                "Path": window?.location?.pathname ?? '<null>',
+                "Search": window?.location?.search ?? '<null>',
+                "Hash": window?.location?.hash ?? '<null>',
+            })
+            const pad = loc.max(e => e.key.length);
+            this.infoItems.push({
+                name: "Location",
+                value: ObjToKv(loc).map(e => e.key.padEnd(pad) + ': ' + e.value).join("\n")
+            })
+        } catch (ex) {
+            this.infoItems.push({ name: "Location", value: "(error printing location, please include the url in your bug report)" });
         }
 
 

--- a/frontend/src/components/pages/schemas/Schema.Details.tsx
+++ b/frontend/src/components/pages/schemas/Schema.Details.tsx
@@ -1,38 +1,23 @@
-import { Col, Descriptions, Row, Select, Statistic, Table } from 'antd';
+import { Col, Descriptions, Row, Select, Statistic, Table, Tag } from 'antd';
 import Card from '../../misc/Card';
 import { observer } from 'mobx-react';
 import React from 'react';
 import { appGlobal } from '../../../state/appGlobal';
 import { api } from '../../../state/backendApi';
 import { PageComponent, PageInitHelper } from '../Page';
-import { DefaultSkeleton, Label, toSafeString } from '../../../utils/tsxUtils';
+import { DefaultSkeleton, Label, OptionGroup, QuickTable, toSafeString } from '../../../utils/tsxUtils';
 import { motion } from 'framer-motion';
 import { animProps } from '../../../utils/animationProps';
 import { KowlJsonView } from '../../misc/KowlJsonView';
 import { sortField } from '../../misc/common';
 import { SchemaField } from '../../../state/restInterfaces';
+import { uiSettings } from '../../../state/ui';
 
 export interface SchemaDetailsProps {
     subjectName: string;
     query: {
         version: number;
     };
-}
-
-function renderSchemaDataList(entries: string[][]) {
-    return (
-        <Descriptions bordered size="small" colon={true} layout="horizontal" column={1}>
-            {entries
-                .filter(([_, text]) => text !== undefined)
-                .map(([label, text]) => (
-                    <Descriptions.Item label={label} key={label}>{toSafeString(text)}</Descriptions.Item>
-                ))}
-        </Descriptions>
-    );
-}
-
-function renderOptions(options: number[] = []) {
-    return options.map((option) => <Select.Option value={option} key={option}>Version {option}</Select.Option>);
 }
 
 function renderSchemaType(value: any, record: SchemaField, index: number) {
@@ -42,10 +27,9 @@ function renderSchemaType(value: any, record: SchemaField, index: number) {
 @observer
 class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
     initPage(p: PageInitHelper): void {
-        const {
-            subjectName,
-            query: { version },
-        } = this.props;
+        const subjectName = this.props.subjectName;
+        const version = this.props.query.version;
+
         p.title = subjectName;
         p.addBreadcrumb('Schema Registry', '/schema-registry');
         p.addBreadcrumb(subjectName, `/schema-registry/${subjectName}?version=${version}`);
@@ -64,17 +48,14 @@ class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
     }
 
     render() {
-        /*
         if (!api.schemaDetails) return DefaultSkeleton;
-*/
-        // const {
-        //     schemaId,
-        //     schema: { type, name, namespace, doc, fields },
-        // } = api.schemaDetails;
+
         const {
             schemaId,
             schema: { type, name, namespace, doc, fields },
-        } = debug.schemaDetails;
+        } = api.schemaDetails;
+
+        const versions = api.schemaDetails?.registeredVersions ?? [];
 
         return (
             <motion.div {...animProps} key={'b'} style={{ margin: '0 1rem' }}>
@@ -85,24 +66,52 @@ class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
                     </Row>
                 </Card>
                 <Card>
-                    <Row gutter={[32, 24]}>
-                        <Col span="24">
-                            <span>
-                                <Label text="Version">
-                                    <Select defaultValue={this.props.query.version} onChange={(version) => appGlobal.history.push(`/schema-registry/${this.props.subjectName}?version=${version}`)}>
-                                        {renderOptions(debug.schemaDetails?.registeredVersions)}
-                                    </Select>
-                                </Label>
-                            </span>
-                        </Col>
-                    </Row>
-                    <Row gutter={32}>
-                        <Col xl={{ span: 12, order: 1 }} xs={{ span: 24, order: 2 }}>
-                            {/* Raw json view of SchemaDetails */}
+                    <div style={{ display: 'flex', alignItems: 'flex-start', columnGap: '1.5em', marginBottom: '1em' }}>
+                        <Label text="Version">
+                            <Select style={{ minWidth: '200px' }}
+                                defaultValue={this.props.query.version}
+                                onChange={(version) => appGlobal.history.push(`/schema-registry/${this.props.subjectName}?version=${version}`)}
+                                disabled={versions.length == 0}
+                            >
+                                {versions.map(v => <Select.Option value={v} key={v}>Version {v}</Select.Option>)}
+                            </Select>
+                        </Label>
+
+                        <Label text='Details' style={{ alignSelf: 'stretch' }}>
+                            <div style={{ display: 'inline-flex', flexWrap: 'wrap', minHeight: '32px', alignItems: 'center', rowGap: '.3em' }}>
+                                {Object.entries({
+                                    "Type": type,
+                                    "Name": name,
+                                    "Namespace": namespace,
+                                }).map(([k, v]) => {
+                                    if (!k || v === undefined || v === null) return null;
+                                    return <Tag color='blue' key={k}><span style={{ color: '#2d5b86' }}>{k}:</span> {toSafeString(v)}</Tag>
+                                })}
+                                {!!doc && <a href={doc}>
+                                    <Tag color='blue' style={{ cursor: 'pointer' }}><span style={{ color: '#2d5b86' }}>Documentation:</span> <a style={{ textDecoration: 'underline' }} href={doc}>{doc}</a></Tag>
+                                </a>}
+                            </div>
+
+                        </Label>
+                    </div>
+
+                    <div style={{ marginBottom: '1.5em' }}>
+                        <OptionGroup label=''
+                            options={{
+                                "Show Fields": 'fields',
+                                "Show raw JSON": 'json',
+                            }}
+                            value={uiSettings.schemaDetails.viewMode}
+                            onChange={s => uiSettings.schemaDetails.viewMode = s}
+                        />
+                    </div>
+
+                    <div>
+                        {uiSettings.schemaDetails.viewMode == 'json' &&
                             <KowlJsonView
                                 shouldCollapse={false}
                                 collapsed={false}
-                                src={debug.schemaDetails || {}}
+                                src={api.schemaDetails || {}}
                                 style={{
                                     border: 'solid thin lightgray',
                                     borderRadius: '.25em',
@@ -110,16 +119,11 @@ class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
                                     marginBottom: '1.5rem',
                                 }}
                             />
-                        </Col>
-                        <Col xl={{ span: 12, order: 2 }} xs={{ span: 24, order: 1 }}>
-                            {renderSchemaDataList([
-                                ['type', type],
-                                ['name', name],
-                                ['namespace', namespace],
-                                ['doc', doc],
-                            ])}
+                        }
+
+                        {uiSettings.schemaDetails.viewMode == 'fields' &&
                             <Table
-                                size="middle"
+                                size="small"
                                 columns={[
                                     { title: 'Name', dataIndex: 'name', className: 'whiteSpaceDefault', }, // sorter: sortField('name')
                                     { title: 'Type', dataIndex: 'type', className: 'whiteSpaceDefault', render: renderSchemaType }, //  sorter: sortField('type'),
@@ -134,9 +138,10 @@ class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
                                     marginTop: '1.5rem',
                                     marginBottom: '1.5rem',
                                 }}
-                            ></Table>
-                        </Col>
-                    </Row>
+                            />
+                        }
+
+                    </div>
                 </Card>
             </motion.div>
         );
@@ -145,293 +150,3 @@ class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
 
 export default SchemaDetailsView;
 
-
-const debug = {
-    "schemaDetails": {
-        "string": "pre-ident-schema-entry-value",
-        "schemaId": 106,
-        "version": 22,
-        "schema": {
-            "doc": "MISSING",
-            "fields": [{
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "long"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "long"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "long"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "int"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "int"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "int"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "int"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "int"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "int"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "int"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "int"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "int"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "int"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "double"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "double"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "double"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "double"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "double"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "double"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "double"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "double"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "double"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "boolean"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "boolean"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", "string"]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", {
-                    "items": ["null", "double"],
-                    "type": "array"
-                }
-                ]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", {
-                    "items": ["null", {
-                        "fields": [
-                        ],
-                        "name": "KsqlDataSourceSchema_qwertz",
-                        "type": "record"
-                    }
-                    ],
-                    "type": "array"
-                }
-                ]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", {
-                    "items": ["null", "string"],
-                    "type": "array"
-                }
-                ]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", {
-                    "items": {
-                        "connect.internal.type": "MapEntry",
-                        "fields": [
-                        ],
-                        "name": "KsqlDataSourceSchema_qwertz",
-                        "type": "record"
-                    },
-                    "type": "array"
-                }
-                ]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", {
-                    "items": {
-                        "connect.internal.type": "MapEntry",
-                        "fields": [
-                        ],
-                        "name": "KsqlDataSourceSchema_qwertz",
-                        "type": "record"
-                    },
-                    "type": "array"
-                }
-                ]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", {
-                    "items": ["null", {
-                        "fields": [
-                        ],
-                        "name": "KsqlDataSourceSchema_qwertz",
-                        "type": "record"
-                    }
-                    ],
-                    "type": "array"
-                }
-                ]
-            }, {
-                "default": null,
-                "name": "qwertz",
-                "type": ["null", {
-                    "items": ["null", {
-                        "fields": [
-                        ],
-                        "name": "KsqlDataSourceSchema_qwertz",
-                        "type": "record"
-                    }
-                    ],
-                    "type": "array"
-                }
-                ]
-            }, {
-                "default": null,
-                "name": "douts",
-                "type": ["null", {
-                    "items": {
-                        "connect.internal.type": "MapEntry",
-                        "fields": [{
-                            "default": null,
-                            "name": "key",
-                            "type": ["null", "string"]
-                        }, {
-                            "default": null,
-                            "name": "value",
-                            "type": ["null", "boolean"]
-                        }
-                        ],
-                        "name": "KsqlDataSourceSchema_qwertz",
-                        "type": "record"
-                    },
-                    "type": "array"
-                }
-                ]
-            }, {
-                "default": null,
-                "name": "extra",
-                "type": ["null", "string"]
-            }
-            ],
-            "name": "KsqlDataSourceSchema",
-            "namespace": "io.confluent.ksql.avro_schemas",
-            "type": "record"
-        },
-        "registeredVersions": [21, 22]
-    },
-    "isConfigured": true
-};

--- a/frontend/src/components/pages/schemas/Schema.Details.tsx
+++ b/frontend/src/components/pages/schemas/Schema.Details.tsx
@@ -5,11 +5,12 @@ import React from 'react';
 import { appGlobal } from '../../../state/appGlobal';
 import { api } from '../../../state/backendApi';
 import { PageComponent, PageInitHelper } from '../Page';
-import { DefaultSkeleton, Label } from '../../../utils/tsxUtils';
+import { DefaultSkeleton, Label, toSafeString } from '../../../utils/tsxUtils';
 import { motion } from 'framer-motion';
 import { animProps } from '../../../utils/animationProps';
 import { KowlJsonView } from '../../misc/KowlJsonView';
 import { sortField } from '../../misc/common';
+import { SchemaField } from '../../../state/restInterfaces';
 
 export interface SchemaDetailsProps {
     subjectName: string;
@@ -24,7 +25,7 @@ function renderSchemaDataList(entries: string[][]) {
             {entries
                 .filter(([_, text]) => text !== undefined)
                 .map(([label, text]) => (
-                    <Descriptions.Item label={label} key={label}>{text}</Descriptions.Item>
+                    <Descriptions.Item label={label} key={label}>{toSafeString(text)}</Descriptions.Item>
                 ))}
         </Descriptions>
     );
@@ -32,6 +33,10 @@ function renderSchemaDataList(entries: string[][]) {
 
 function renderOptions(options: number[] = []) {
     return options.map((option) => <Select.Option value={option} key={option}>Version {option}</Select.Option>);
+}
+
+function renderSchemaType(value: any, record: SchemaField, index: number) {
+    return toSafeString(value);
 }
 
 @observer
@@ -59,12 +64,17 @@ class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
     }
 
     render() {
+        /*
         if (!api.schemaDetails) return DefaultSkeleton;
-
+*/
+        // const {
+        //     schemaId,
+        //     schema: { type, name, namespace, doc, fields },
+        // } = api.schemaDetails;
         const {
             schemaId,
             schema: { type, name, namespace, doc, fields },
-        } = api.schemaDetails;
+        } = debug.schemaDetails;
 
         return (
             <motion.div {...animProps} key={'b'} style={{ margin: '0 1rem' }}>
@@ -80,7 +90,7 @@ class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
                             <span>
                                 <Label text="Version">
                                     <Select defaultValue={this.props.query.version} onChange={(version) => appGlobal.history.push(`/schema-registry/${this.props.subjectName}?version=${version}`)}>
-                                        {renderOptions(api.schemaDetails?.registeredVersions)}
+                                        {renderOptions(debug.schemaDetails?.registeredVersions)}
                                     </Select>
                                 </Label>
                             </span>
@@ -88,8 +98,11 @@ class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
                     </Row>
                     <Row gutter={32}>
                         <Col xl={{ span: 12, order: 1 }} xs={{ span: 24, order: 2 }}>
+                            {/* Raw json view of SchemaDetails */}
                             <KowlJsonView
-                                src={api.schemaDetails || {}}
+                                shouldCollapse={false}
+                                collapsed={false}
+                                src={debug.schemaDetails || {}}
                                 style={{
                                     border: 'solid thin lightgray',
                                     borderRadius: '.25em',
@@ -108,8 +121,8 @@ class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
                             <Table
                                 size="middle"
                                 columns={[
-                                    { title: 'Name', dataIndex: 'name', className: 'whiteSpaceDefault', sorter: sortField('name') },
-                                    { title: 'Type', dataIndex: 'type', className: 'whiteSpaceDefault', sorter: sortField('type') },
+                                    { title: 'Name', dataIndex: 'name', className: 'whiteSpaceDefault', }, // sorter: sortField('name')
+                                    { title: 'Type', dataIndex: 'type', className: 'whiteSpaceDefault', render: renderSchemaType }, //  sorter: sortField('type'),
                                     { title: 'Default', dataIndex: 'default', className: 'whiteSpaceDefault' },
                                     { title: 'Documentation', dataIndex: 'doc', className: 'whiteSpaceDefault' },
                                 ]}
@@ -131,3 +144,294 @@ class SchemaDetailsView extends PageComponent<SchemaDetailsProps> {
 }
 
 export default SchemaDetailsView;
+
+
+const debug = {
+    "schemaDetails": {
+        "string": "pre-ident-schema-entry-value",
+        "schemaId": 106,
+        "version": 22,
+        "schema": {
+            "doc": "MISSING",
+            "fields": [{
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "long"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "long"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "long"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "int"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "int"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "int"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "int"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "int"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "int"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "int"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "int"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "int"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "int"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "double"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "double"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "double"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "double"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "double"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "double"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "double"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "double"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "double"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "boolean"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "boolean"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", "string"]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", {
+                    "items": ["null", "double"],
+                    "type": "array"
+                }
+                ]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", {
+                    "items": ["null", {
+                        "fields": [
+                        ],
+                        "name": "KsqlDataSourceSchema_qwertz",
+                        "type": "record"
+                    }
+                    ],
+                    "type": "array"
+                }
+                ]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", {
+                    "items": ["null", "string"],
+                    "type": "array"
+                }
+                ]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", {
+                    "items": {
+                        "connect.internal.type": "MapEntry",
+                        "fields": [
+                        ],
+                        "name": "KsqlDataSourceSchema_qwertz",
+                        "type": "record"
+                    },
+                    "type": "array"
+                }
+                ]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", {
+                    "items": {
+                        "connect.internal.type": "MapEntry",
+                        "fields": [
+                        ],
+                        "name": "KsqlDataSourceSchema_qwertz",
+                        "type": "record"
+                    },
+                    "type": "array"
+                }
+                ]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", {
+                    "items": ["null", {
+                        "fields": [
+                        ],
+                        "name": "KsqlDataSourceSchema_qwertz",
+                        "type": "record"
+                    }
+                    ],
+                    "type": "array"
+                }
+                ]
+            }, {
+                "default": null,
+                "name": "qwertz",
+                "type": ["null", {
+                    "items": ["null", {
+                        "fields": [
+                        ],
+                        "name": "KsqlDataSourceSchema_qwertz",
+                        "type": "record"
+                    }
+                    ],
+                    "type": "array"
+                }
+                ]
+            }, {
+                "default": null,
+                "name": "douts",
+                "type": ["null", {
+                    "items": {
+                        "connect.internal.type": "MapEntry",
+                        "fields": [{
+                            "default": null,
+                            "name": "key",
+                            "type": ["null", "string"]
+                        }, {
+                            "default": null,
+                            "name": "value",
+                            "type": ["null", "boolean"]
+                        }
+                        ],
+                        "name": "KsqlDataSourceSchema_qwertz",
+                        "type": "record"
+                    },
+                    "type": "array"
+                }
+                ]
+            }, {
+                "default": null,
+                "name": "extra",
+                "type": ["null", "string"]
+            }
+            ],
+            "name": "KsqlDataSourceSchema",
+            "namespace": "io.confluent.ksql.avro_schemas",
+            "type": "record"
+        },
+        "registeredVersions": [21, 22]
+    },
+    "isConfigured": true
+};

--- a/frontend/src/state/restInterfaces.ts
+++ b/frontend/src/state/restInterfaces.ts
@@ -450,7 +450,7 @@ export interface Schema {
 
 export interface SchemaField {
     name: string;
-    type: string;
-    doc: string;
-    default?: string;
+    type: string | object | null | undefined;
+    doc?: string | null | undefined;
+    default?: string | object | null | undefined;
 }

--- a/frontend/src/state/ui.ts
+++ b/frontend/src/state/ui.ts
@@ -136,6 +136,10 @@ const uiSettings = observable({
         quickSearch: ''
     },
 
+    schemaDetails: {
+        viewMode: 'fields' as 'json' | 'fields',
+    },
+
     previewNotificationHideUntil: 0, // utc seconds
 
     userDefaults: {

--- a/frontend/src/utils/tsxUtils.tsx
+++ b/frontend/src/utils/tsxUtils.tsx
@@ -1,5 +1,5 @@
 import React, { useState, Component, CSSProperties } from "react";
-import { simpleUniqueId, DebugTimerStore } from "./utils";
+import { simpleUniqueId, DebugTimerStore, ToJson } from "./utils";
 import { Radio, message, Progress, Skeleton } from 'antd';
 import { MessageType } from "antd/lib/message";
 import prettyMilliseconds from 'pretty-ms';
@@ -102,9 +102,9 @@ export function QuickTable(data: { key: any, value: any }[] | [any, any][], opti
             {entries.map((obj, i) =>
                 <React.Fragment key={i}>
                     <tr>
-                        <td style={{ textAlign: o.keyAlign, ...o.keyStyle }} className='keyCell'>{obj.key}</td>
+                        <td style={{ textAlign: o.keyAlign, ...o.keyStyle }} className='keyCell'>{toSafeString(obj.key)}</td>
                         <td style={{ minWidth: '0px', width: o.gapWidth, padding: '0px' }}></td>
-                        <td style={{ ...o.valueStyle }} className='valueCell'>{obj.value}</td>
+                        <td style={{ ...o.valueStyle }} className='valueCell'>{toSafeString(obj.value)}</td>
                     </tr>
 
                     {showVerticalGutter && (i < entries.length - 1) &&
@@ -116,6 +116,12 @@ export function QuickTable(data: { key: any, value: any }[] | [any, any][], opti
             )}
         </tbody>
     </table>
+}
+
+export function toSafeString(x: any): string {
+    if (typeof x === 'undefined' || x === null) return "";
+    if (typeof x === 'string' || typeof x === 'boolean') return String(x);
+    return ToJson(x);
 }
 
 export function ObjToKv(obj: any): { key: string, value: any }[] {


### PR DESCRIPTION
Issue #143 reported an issue when the frontend tried to show "complex" schema types, e.g. non primitive types like number, string, etc.

Since the fields table now potentially requires a lot more width, I also redesigned the layout of Schema.Details.tsx a bit.
