### PR TITLE
Fix null value as empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - [CHANGE] We removed the Kafka library and replaced it with [franz-go](https://github.com/twmb/franz-go). This allows us to add a lot more features in the future.
 - [CHANGE] Configuration for the topic documentation feature has changed
+- [CHANGE] When the root "value" of a message has 0 bytes, it is now correctly deserialized to `nil` instead of `""`. If you use filters in the frontend to filter tombstones you probably used `value != ""` before, but with this change you'll have to use `value != null`.
 - [FEATURE] Support setting the listen adress of the webserver (config entry: `server.http.listen-address`, or flag: `listenAddress`). [#150](https://github.com/cloudhut/kowl/issues/150) 
 - **[FEATURE] Add Protobuf support**
 - **[FEATURE] Preview Tags has been reworked. Now supports nested tags and autocomplete. Tags can be editted and reordered.**

--- a/backend/pkg/kafka/deserializer.go
+++ b/backend/pkg/kafka/deserializer.go
@@ -6,12 +6,13 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"unicode/utf8"
+
 	"github.com/cloudhut/kowl/backend/pkg/proto"
 	"github.com/twmb/franz-go/pkg/kbin"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"strings"
-	"unicode/utf8"
 
 	xj "github.com/basgys/goxml2json"
 	"github.com/cloudhut/kowl/backend/pkg/schema"
@@ -107,7 +108,7 @@ func (d *deserializer) deserializePayload(payload []byte, topicName string, reco
 		return &deserializedPayload{Payload: normalizedPayload{
 			Payload:            payload,
 			RecognizedEncoding: messageEncodingNone,
-		}, Object: "", RecognizedEncoding: messageEncodingNone, Size: len(payload)}
+		}, Object: nil, RecognizedEncoding: messageEncodingNone, Size: len(payload)}
 	}
 
 	trimmed := bytes.TrimLeft(payload, " \t\r\n")


### PR DESCRIPTION
When `value` is empty (the payload has 0 bytes), it should be deserialized to `nil` instead of an empty string (`""`).

This has no effect on any nested values: `{ someProp: "" }` and `{ someProp: null }` etc will all still be deserialized exactly the same as before.

This fixes the very unintuitive filtering for tombstone messages. 
Previously users had to use `value != ""` to filter tombstones (which made no sense),
and now the way to filter tombstones is `value != null` (as expected).

