### PR TITLE
Add new github ssh host keys for ECDSA and Ed25519.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,6 @@ COPY --from=frontendBuilder /app/build/ /app/build
 
 # Add github.com to known SSH hosts by default (required for pulling topic docs & proto files from a Git repo)
 RUN apk update && apk add --no-cache openssh
-RUN ssh-keyscan -t rsa github.com >> /etc/ssh/ssh_known_hosts
+RUN ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts
 
 ENTRYPOINT ["./kowl"]


### PR DESCRIPTION
kowl fails to clone github repositories because of missing new ssh host keys in the image:

`{"level":"fatal","ts":"2021-11-18T07:08:58.014Z","msg":"failed to start owl service","error":"failed to clone git repo: ssh: handshake failed: knownhosts: key mismatch"}`

For reference:
https://github.blog/2021-09-01-improving-git-protocol-security-github/