### PR TITLE
Fix: topic docs: pull from specified branch

### DIFF
--- a/backend/pkg/git/service.go
+++ b/backend/pkg/git/service.go
@@ -150,7 +150,11 @@ func (c *Service) SyncRepo() {
 			c.logger.Info("stopped sync", zap.String("reason", "received signal"))
 			return
 		case <-ticker.C:
-			err := tree.Pull(&git.PullOptions{Auth: c.auth})
+			var referenceName plumbing.ReferenceName
+			if c.Cfg.Repository.Branch != "" {
+				referenceName = plumbing.NewBranchReferenceName(c.Cfg.Repository.Branch)
+			}
+			err := tree.Pull(&git.PullOptions{Auth: c.auth, ReferenceName: referenceName})
 			if err != nil {
 				if err == git.NoErrAlreadyUpToDate {
 					continue


### PR DESCRIPTION
When using the topic documentation feature, I noticed that Kowl was not pulling topic docs from the configured branch (the branch set with the `OWL_TOPICDOCUMETATION_GIT_REPOSITORY_BRANCH` docker environment variable. Here's the behavior I was seeing:

When I started Kowl, I had a git repository like this:

```
[branch: main]
- topic1.md

[branch: new-branch]
- topic1.md
```

Here are the contents of each of the files:

```
[branch: main] topic1.md
This is my documentation for topic 1
main

[branch: new-branch] topic1.md
This is my documentation for topic 1
new-branch
```

The `OWL_TOPICDOCUMETATION_GIT_REPOSITORY_BRANCH` variable was set to `"new-branch"`. Sure enough, after Kowl cloned the git repository, I saw this message in the logs:
```json
{"level":"info","ts":"2022-02-20T06:14:38.637Z","msg":"successfully cloned git repository","repository_url":"https://github.com/DavidPratt512/test-docs","base_directory":".","read_files":1}
```
The "Documentation" tab in Kowl matches the docs from `new-branch`.

But once Kowl pulls the repository (according to `OWL_TOPICDOCUMENTATION_GIT_REFRESHINTERVAL`) this message shows up in the logs:

```json
{"level":"error","ts":"2022-02-20T06:15:38.826Z","msg":"pulling the repo has failed","repository_url":"https://github.com/DavidPratt512/test-docs","error":"non-fast-forward update"}
```

This means that Kowl is trying to pull the `main` branch into the `new-branch` branch. Oops!

This fix uses the same logic in determining the branch to pull from as the logic when initially cloning the repository.