### PR TITLE
Fix: topic docs: render code blocks

### DIFF
--- a/frontend/src/components/pages/topics/Tab.Docu.tsx
+++ b/frontend/src/components/pages/topics/Tab.Docu.tsx
@@ -56,6 +56,7 @@ export class TopicDocumentation extends Component<{ topic: Topic }> {
                 margin: null,
                 padding: null,
             }}
+            PreTag="div"
             language={match[1]}
             children={String(children).replace(/\n$/, '')} {...props} />
           ) : (

--- a/frontend/src/components/pages/topics/Tab.Docu.tsx
+++ b/frontend/src/components/pages/topics/Tab.Docu.tsx
@@ -59,7 +59,7 @@ export class TopicDocumentation extends Component<{ topic: Topic }> {
             language={match[1]}
             children={String(children).replace(/\n$/, '')} {...props} />
           ) : (
-            <code className={className} {...props} />
+            <code className={className} {...props}>{children}</code>
           )
         }
       }


### PR DESCRIPTION
Resolves #323.

Looks like we were missing `{children}` inside of the `<code>` tags. That would definitely explain why they were empty.

Additionally, code blocks were wrapped in two `<pre>` tags. The HTML looked something like this:

```html
<pre>
    <pre style="...">
        <code>...</code>
    </pre>
</pre>
```

This made code blocks with highlighting look... blocky.

![image](https://user-images.githubusercontent.com/26131314/156517037-06949fe9-73b5-402f-9710-e432f4481c0a.png)

Using `PreTag="div"` will change the inner `<pre>` tag into a `<div>`. Now we have less "blocky" visuals:

![image](https://user-images.githubusercontent.com/26131314/156516664-2304a598-099e-42e3-9321-b86be87a6313.png)


([Reference docs](https://github.com/remarkjs/react-markdown#use-custom-components-syntax-highlight))